### PR TITLE
Relax dependency on Sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
 gem 'rake'
-gem 'sass', '3.2.15'
+gem 'sass', '~> 3.2'
 gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,5 +10,5 @@ PLATFORMS
 
 DEPENDENCIES
   rake
-  sass (= 3.2.15)
+  sass (~> 3.2)
   webrick


### PR DESCRIPTION
Relax dependency on the Sass gem to use any version from 3.2.x up to but
not including 4.0.

We use `Gemfile.lock` to specify known working versions so this should
not cause any issues.