### PR TITLE
Enable support for speaker notes via console.info()

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,19 @@
       </p>
     </div></section>
 
+    <section class="slide">
+      <div>
+        <h2>Speaker notes</h2>
+        <p>View this slide in presentation mode and open up your browser's console...</p>
+      </div>
+
+      <footer>
+        Write your notes here - they're shown using console.info().
+        You can undock the console into a separate window to have your notes on another screen while you're speaking.
+        The h2 in the next slide is also shown automatically:
+      </footer>
+    </section>
+
     <section class="slide"><div>
       <h2>Quotes</h2>
       <figure>

--- a/styles/gds.scss
+++ b/styles/gds.scss
@@ -258,6 +258,7 @@ a {
     }
   }
 
+  // Blue slide footer
   .footer {
     position: absolute;
     bottom: 0;
@@ -273,6 +274,11 @@ a {
     .right {
       float: right;
     }
+  }
+
+  // Speaker notes
+  footer {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Shower supports speaker notes via a `<footer>` element in a slide which is sent to `console.info()`.

- set `display: none` to prevent the `<footer>` element being overlaid on the slide
- add a comment to the `.footer` styles to avoid potential naming confusion
- add an example slide to show how to use this feature